### PR TITLE
Added full CRUD support for user projects (MVC backend + frontend integration)

### DIFF
--- a/client/src/assets/components/profile/ProjectsSec/Project.jsx
+++ b/client/src/assets/components/profile/ProjectsSec/Project.jsx
@@ -14,8 +14,7 @@ import { useSuccessToast } from "../../toast/useSuccessToast";
 
 function Project() {
   const [showAll, setShowAll] = useState(false);
-  const [projects, setProjects] = useState([
-    {
+  const [projects, setProjects] = useState([{
       title: "",
       duration: "",
       description: "",
@@ -25,9 +24,8 @@ function Project() {
         videos: [],
       },
       liveLink: "",
-      sourceCodeLink: "",
-    },
-  ]);
+      sourceCodeLink: ""
+    }])
 
   const { auth } = useAuth();
   const { profile } = useContext(ProfileContext);
@@ -66,7 +64,7 @@ function Project() {
 
   const fetchProjects = async () => {
     try {
-      const response = await axiosPrivate.get("/project/allProjects", {
+      const response = await axiosPrivate.get("/projects/allProjects", {
         headers: {
           Authorization: `Bearer ${auth?.accessToken}`,
         },
@@ -81,7 +79,7 @@ function Project() {
   const handleDelete = async (id) => {
     console.log("delete project", id);
     try {
-      const deleteProject = await axiosPrivate.delete(`/project/${id}`, {
+      const deleteProject = await axiosPrivate.delete(`/projects/${id}`, {
         headers: {
           Authorization: `Bearer ${auth?.accessToken}`,
         },
@@ -105,8 +103,6 @@ function Project() {
       );
       showSuccess("Project updated successfully");
     } else {
-      const id = Date.now();
-      setProjects((prev) => [...prev, { ...newProject, id }]);
       showSuccess("Project added successfully");
     }
     setIsModalOpen(false);
@@ -137,7 +133,8 @@ function Project() {
       </div>
 
       <div className="mt-3 flex flex-col space-y-4">
-        {(showAll ? projects : projects.slice(0, 2)).map((project) => (
+
+        {projects.length>0 ? (showAll ? projects : projects.slice(0, 2)).map((project) => (
           <ProjectCopo
             key={project.id}
             project={project}
@@ -146,7 +143,10 @@ function Project() {
             canDelete={canDelete}
             onDelete={handleDelete}
           />
-        ))}
+        )): <div className="text-center text-gray-600 mb-3 bg-[#20252e] p-10 rounded-lg">
+             <p className="text-lg font-bold">No projects were added yet</p>
+             <p className="text-sm mt-2">Create a project to see it listed here.</p>
+        </div>}
 
         {projects.length > 2 && (
           <button

--- a/client/src/assets/components/profile/ProjectsSec/Project.jsx
+++ b/client/src/assets/components/profile/ProjectsSec/Project.jsx
@@ -14,18 +14,7 @@ import { useSuccessToast } from "../../toast/useSuccessToast";
 
 function Project() {
   const [showAll, setShowAll] = useState(false);
-  const [projects, setProjects] = useState([{
-      title: "",
-      duration: "",
-      description: "",
-      techStack: "",
-      media: {
-        images: [],
-        videos: [],
-      },
-      liveLink: "",
-      sourceCodeLink: ""
-    }])
+  const [projects, setProjects] = useState([])
 
   const { auth } = useAuth();
   const { profile } = useContext(ProfileContext);
@@ -93,14 +82,9 @@ function Project() {
     fetchProjects();
   };
 
-  const handleSave = async (newProject) => {
+  const handleSave = async () => {
    try {
     if (editProject) {
-      setProjects((prev) =>
-        prev.map((p) =>
-          p.id === editProject.id ? { ...newProject, id: p.id } : p
-        )
-      );
       showSuccess("Project updated successfully");
     } else {
       showSuccess("Project added successfully");
@@ -134,9 +118,9 @@ function Project() {
 
       <div className="mt-3 flex flex-col space-y-4">
 
-        {projects.length>0 ? (showAll ? projects : projects.slice(0, 2)).map((project) => (
+        {projects.length>0 ? (showAll ? projects : projects.slice(0, 2)).map((project,index) => (
           <ProjectCopo
-            key={project.id}
+            key={project._id || project.id || index}
             project={project}
             onEdit={() => handleEdit(project)}
             canEdit={canEdit}

--- a/client/src/assets/components/profile/ProjectsSec/Project.jsx
+++ b/client/src/assets/components/profile/ProjectsSec/Project.jsx
@@ -1,22 +1,31 @@
-import { FaPlus, FaArrowRight } from "react-icons/fa";
+import { FaPlus, FaArrowRight,FaCheckCircle,FaTimesCircle } from "react-icons/fa";
 import ProjectCopo from "./ProjectCopo";
 import ProjectModal from "./ProjectModal";
 import useAuth from "../../../../auth/useAuth";
 import ProfileContext from "../../../context/ProfileContext";
-import { useState, useContext } from "react";
+import { useState, useContext, useEffect } from "react";
+import { axiosPrivate } from "../../../../api/axios";
+
+// Toast imports
+import ErrorToast from "../../toast/ErrorToast";
+import { useErrorToast } from "../../toast/useErrorToast";
+import SuccessToast from "../../toast/SuccessToast";
+import { useSuccessToast } from "../../toast/useSuccessToast";
 
 function Project() {
   const [showAll, setShowAll] = useState(false);
   const [projects, setProjects] = useState([
     {
-      id: 1,
-      title: "Mobile Recycle",
-      duration: "Jan 2025-2026",
-      description:
-        "Lorem ipsum dolor sit amet consectetur adipisicing elit. Ut, at dolorem...",
-      skills: "React.js, Node.js, express.js",
-      image:
-        "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTlKC5yJhCCyjyhrC-2XBv3H4i1-ojuLblUlg&s",
+      title: "",
+      duration: "",
+      description: "",
+      techStack: "",
+      media: {
+        images: [],
+        videos: [],
+      },
+      liveLink: "",
+      sourceCodeLink: "",
     },
   ]);
 
@@ -26,33 +35,92 @@ function Project() {
   const isOwnProfile = auth?.username === profile?.username;
   const isAdminOrOwner = ["admin", "owner"].includes(auth?.role);
   const canEdit = isOwnProfile || isAdminOrOwner;
+  const canDelete = isOwnProfile || isAdminOrOwner;
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editProject, setEditProject] = useState(null);
+
+   const {
+      message: errorMessage,
+      show: showErrorToast,
+      showError,
+    } = useErrorToast();
+  
+    const {
+      message: successMessage,
+      show: showSuccessToast,
+      showSuccess,
+    } = useSuccessToast();
 
   const handleAdd = () => {
     setEditProject(null);
     setIsModalOpen(true);
   };
 
+
   const handleEdit = (project) => {
     setEditProject(project);
     setIsModalOpen(true);
+    console.log("edit project", project._id);
   };
 
-  const handleSave = (newProject) => {
+  const fetchProjects = async () => {
+    try {
+      const response = await axiosPrivate.get("/project/allProjects", {
+        headers: {
+          Authorization: `Bearer ${auth?.accessToken}`,
+        },
+      });   
+      setProjects(response.data);
+    } catch (err) {
+      showError("Failed to fetch projects")
+      console.log(err);
+    }
+  };
+
+  const handleDelete = async (id) => {
+    console.log("delete project", id);
+    try {
+      const deleteProject = await axiosPrivate.delete(`/project/${id}`, {
+        headers: {
+          Authorization: `Bearer ${auth?.accessToken}`,
+        },
+      });
+      if(deleteProject.status===200){
+        showSuccess("Project deleted successfully")
+      }
+    } catch (err) {
+      showError("Failed to delete project")
+    }
+    fetchProjects();
+  };
+
+  const handleSave = async (newProject) => {
+   try {
     if (editProject) {
       setProjects((prev) =>
         prev.map((p) =>
           p.id === editProject.id ? { ...newProject, id: p.id } : p
         )
       );
+      showSuccess("Project updated successfully");
     } else {
       const id = Date.now();
       setProjects((prev) => [...prev, { ...newProject, id }]);
+      showSuccess("Project added successfully");
     }
     setIsModalOpen(false);
+    fetchProjects();
+  } catch (err) {
+    showError("Failed to save project");
+  }
   };
+
+  useEffect(() => {
+    if (auth?.accessToken) {
+      fetchProjects();
+    }
+  }, [auth?.accessToken]);
 
   return (
     <div className="max-w-[90%] lg:max-w-4xl mx-auto p-6 bg-base-100 rounded-lg shadow-md mt-5 relative">
@@ -75,6 +143,8 @@ function Project() {
             project={project}
             onEdit={() => handleEdit(project)}
             canEdit={canEdit}
+            canDelete={canDelete}
+            onDelete={handleDelete}
           />
         ))}
 
@@ -96,6 +166,23 @@ function Project() {
           initialData={editProject}
         />
       )}
+
+       <SuccessToast
+        message={successMessage}
+        show={showSuccessToast}
+        status="success"
+        icon={
+          <FaCheckCircle className="text-green-600 text-4xl bg-transparent p-0 m-0" />
+        }
+        iconBgColor="bg-blue-200"
+      />
+      <ErrorToast
+        message={errorMessage}
+        show={showErrorToast}
+        status="error"
+        icon={<FaTimesCircle className="text-red-600 text-4xl" />}
+        iconBgColor="bg-red-700"
+      />
     </div>
   );
 }

--- a/client/src/assets/components/profile/ProjectsSec/Project.jsx
+++ b/client/src/assets/components/profile/ProjectsSec/Project.jsx
@@ -5,6 +5,7 @@ import useAuth from "../../../../auth/useAuth";
 import ProfileContext from "../../../context/ProfileContext";
 import { useState, useContext, useEffect } from "react";
 import { axiosPrivate } from "../../../../api/axios";
+import ThemeContext from "../../../context/ThemeContext";
 
 // Toast imports
 import ErrorToast from "../../toast/ErrorToast";
@@ -13,6 +14,7 @@ import SuccessToast from "../../toast/SuccessToast";
 import { useSuccessToast } from "../../toast/useSuccessToast";
 
 function Project() {
+  const { darkMode } = useContext(ThemeContext);
   const [showAll, setShowAll] = useState(false);
   const [projects, setProjects] = useState([])
 
@@ -127,7 +129,11 @@ function Project() {
             canDelete={canDelete}
             onDelete={handleDelete}
           />
-        )): <div className="text-center text-gray-600 mb-3 bg-[#20252e] p-10 rounded-lg">
+        )): <div className={`text-center ${
+            darkMode
+              ? "bg-[#20252e] text-gray-600"
+              : "bg-[#d8dee9] opacity-70"
+          } p-10 rounded-lg`}>
              <p className="text-lg font-bold">No projects were added yet</p>
              <p className="text-sm mt-2">Create a project to see it listed here.</p>
         </div>}

--- a/client/src/assets/components/profile/ProjectsSec/ProjectCopo.jsx
+++ b/client/src/assets/components/profile/ProjectsSec/ProjectCopo.jsx
@@ -43,7 +43,10 @@ function ProjectCopo({ project, onEdit, canEdit ,onDelete }) {
 
             <h3 className="font-semibold">
               Tech Stack:{" "}
-              <span className="font-normal">{project.techStack}</span>
+              {project?.techStack?.map((item,index)=>(
+                      <span className="font-normal" key={index}>{index > 0 && ", "}{item}</span>
+              ))}
+             
             </h3>
             <h3 className="font-semibold">
               Description:{" "}

--- a/client/src/assets/components/profile/ProjectsSec/ProjectCopo.jsx
+++ b/client/src/assets/components/profile/ProjectsSec/ProjectCopo.jsx
@@ -1,32 +1,85 @@
-import { FaEdit } from "react-icons/fa";
+import { FaEdit, FaGithub, FaGlobe, FaTrash } from "react-icons/fa";
 import { useContext } from "react";
 import ThemeContext from "../../../context/ThemeContext";
 
-function ProjectCopo({ project, onEdit, canEdit }) {
+function ProjectCopo({ project, onEdit, canEdit ,onDelete }) {
   const { darkMode } = useContext(ThemeContext);
+  console.log(project);
 
   return (
     <div className="relative mt-3 p-3 pl-5 bg-base-300 rounded-lg">
       {canEdit && (
         <div
           className={`absolute shadow-md top-3 p-2 rounded-3xl right-4 cursor-pointer text-xl text-primary hover:opacity-100
-          ${darkMode ? "bg-[rgb(42,48,60)] opacity-90" : "bg-[#ffffffa6] opacity-70"}`}
+          ${
+            darkMode
+              ? "bg-[rgb(42,48,60)] opacity-90"
+              : "bg-[#ffffffa6] opacity-70"
+          }`}
           onClick={onEdit}
         >
           <FaEdit />
         </div>
       )}
-      <h1 className="font-medium">{project.title}</h1>
-      <h6>{project.duration}</h6>
-      <h3>Description: {project.description}</h3>
-      <h3>Skill: {project.skills}</h3>
-      {project.image && (
-        <img
-          className="h-[100px] mt-2 rounded"
-          src={project.image}
-          alt="project"
-        />
-      )}
+      {
+        (
+          <div
+          className={`absolute shadow-md top-14 p-2 rounded-3xl right-4 cursor-pointer text-xl text-primary hover:opacity-100
+          ${
+            darkMode
+              ? "bg-[rgb(42,48,60)] opacity-90"
+              : "bg-[#ffffffa6] opacity-70"
+          }`}
+          onClick={()=>onDelete(project._id)}
+        >
+          <FaTrash/>
+        </div>
+        )
+      }
+      <div className="grid grid-cols-[60%_40%] gap-3">
+        <div className="left flex flex-col items-start gap-3 justify-between">
+          <div className="flex flex-col gap-3">
+            <h1 className="font-bold text-xl mt-2">{project.title}</h1>
+
+            <h3 className="font-semibold">
+              Tech Stack:
+              <span className="font-normal">{project.techStack}</span>
+            </h3>
+            <h3 className="font-semibold">
+              Description:
+              <span className="font-normal">{project.description}</span>
+            </h3>
+          </div>
+
+          <div className="flex gap-5">
+            <a
+              href={project.sourceCodeLink}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <FaGithub size={30} color="black" />
+            </a>
+            <a
+              href={project.livelink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-2 text-black hover:underline text-2xl"
+            >
+              <FaGlobe />
+            </a>
+          </div>
+        </div>
+        <div className="right flex mt-2 flex-col items-end mr-[18%]">
+          <h3 className="sm:mr-6">{project.duration}</h3>
+          {project?.media?.images && (
+            <img
+              className="h-[150px] mt-2 rounded sm:mr-5"
+              src={project.media.images[0]}
+              alt="project"
+            />
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/client/src/assets/components/profile/ProjectsSec/ProjectCopo.jsx
+++ b/client/src/assets/components/profile/ProjectsSec/ProjectCopo.jsx
@@ -42,36 +42,37 @@ function ProjectCopo({ project, onEdit, canEdit ,onDelete }) {
             <h1 className="font-bold text-xl mt-2">{project.title}</h1>
 
             <h3 className="font-semibold">
-              Tech Stack:
+              Tech Stack:{" "}
               <span className="font-normal">{project.techStack}</span>
             </h3>
             <h3 className="font-semibold">
-              Description:
+              Description:{" "}
               <span className="font-normal">{project.description}</span>
             </h3>
           </div>
 
           <div className="flex gap-5">
+            {project.sourceCodeLink && 
             <a
               href={project.sourceCodeLink}
               target="_blank"
               rel="noopener noreferrer"
             >
               <FaGithub size={30} color="black" />
-            </a>
-            <a
+            </a>}
+            {project.liveLink && <a
               href={project.liveLink}
               target="_blank"
               rel="noopener noreferrer"
               className="flex items-center gap-2 text-black hover:underline text-2xl"
             >
               <FaGlobe />
-            </a>
+            </a>}
           </div>
         </div>
         <div className="right flex mt-2 flex-col items-end mr-[18%]">
           <h3 className="sm:mr-6">{project.duration}</h3>
-          {project?.media?.images && (
+          {project?.media?.images[0] && (
             <img
               className="h-[150px] mt-2 rounded sm:mr-5"
               src={project.media.images[0]}

--- a/client/src/assets/components/profile/ProjectsSec/ProjectCopo.jsx
+++ b/client/src/assets/components/profile/ProjectsSec/ProjectCopo.jsx
@@ -4,9 +4,9 @@ import ThemeContext from "../../../context/ThemeContext";
 
 function ProjectCopo({ project, onEdit, canEdit ,onDelete }) {
   const { darkMode } = useContext(ThemeContext);
-  console.log(project);
 
   return (
+   
     <div className="relative mt-3 p-3 pl-5 bg-base-300 rounded-lg">
       {canEdit && (
         <div
@@ -60,7 +60,7 @@ function ProjectCopo({ project, onEdit, canEdit ,onDelete }) {
               <FaGithub size={30} color="black" />
             </a>
             <a
-              href={project.livelink}
+              href={project.liveLink}
               target="_blank"
               rel="noopener noreferrer"
               className="flex items-center gap-2 text-black hover:underline text-2xl"
@@ -81,6 +81,7 @@ function ProjectCopo({ project, onEdit, canEdit ,onDelete }) {
         </div>
       </div>
     </div>
+   
   );
 }
 

--- a/client/src/assets/components/profile/ProjectsSec/ProjectModal.jsx
+++ b/client/src/assets/components/profile/ProjectsSec/ProjectModal.jsx
@@ -12,7 +12,7 @@ function ProjectModal({ onClose, onSave, initialData }) {
     description: initialData?.description || "",
     media: initialData?.media || { images: [], videos: [] },
     sourceCodeLink: initialData?.sourceCodeLink || "",
-    liveLink: initialData?.livelink || "",
+    liveLink: initialData?.liveLink || "",
     techStack: initialData?.techStack || [],
   });
 
@@ -26,12 +26,11 @@ function ProjectModal({ onClose, onSave, initialData }) {
     if (type === "Add") {
       console.log(form);
       try {
-        const response = await axiosPrivate.post("/project/create", form, {
+        const response = await axiosPrivate.post("/projects/create", form, {
           headers: {
             Authorization: `Bearer ${auth?.accessToken}`,
           },
         });
-        console.log(response.data);
       } catch (err) {
         console.log(err);
       }
@@ -52,7 +51,7 @@ function ProjectModal({ onClose, onSave, initialData }) {
 
       try {
         const response = await axiosPrivate.patch(
-          "/project/update",
+          "/projects/update",
           updatedForm,
 
           {
@@ -62,7 +61,6 @@ function ProjectModal({ onClose, onSave, initialData }) {
           }
         );
         onClose(false)
-        console.log("updated project",response.data)
         onSave(response.data)
       } catch (err) {
         console.log(err);

--- a/client/src/assets/components/profile/ProjectsSec/ProjectModal.jsx
+++ b/client/src/assets/components/profile/ProjectsSec/ProjectModal.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { axiosPrivate } from "../../../../api/axios";
 import useAuth from "../../../../auth/useAuth";
-import { FaTimesCircle,FaCheckCircle } from "react-icons/fa";
+import { FaTimesCircle, FaCheckCircle } from "react-icons/fa";
 
 // Toast imports
 import ErrorToast from "../../toast/ErrorToast";
@@ -75,9 +75,8 @@ function ProjectModal({ onClose, onSave, initialData }) {
     if (name === "techStack") {
       setForm({
         ...form,
-        techStack: value
-          .split(",")
-          
+        techStack: value.split(",")
+        .map((t) => t.trim())
       });
     } else {
       setForm({ ...form, [name]: value });
@@ -99,19 +98,19 @@ function ProjectModal({ onClose, onSave, initialData }) {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+
+    const v1 = TITLE_REGEX.test(form.title);
+    const v2 = DURATION_REGEX.test(form.duration);
+    const v3 = DESCRIPTION_REGEX.test(form.description);
+    const v4 = URL_REGEX.test(form.sourceCodeLink) || form.sourceCodeLink === "";
+    const v5 = URL_REGEX.test(form.liveLink) || form.liveLink === "";
+    const v6 = form.techStack.every((t) => TECH_STACK_ITEM_REGEX.test(t));
+
+    if (!v1 || !v2 || !v3 || !v4 || !v5 || !v6) {
+      showError("Invalid Entry");
+      return;
+    }
     if (type === "Add") {
-      const v1 = TITLE_REGEX.test(form.title);
-      const v2 = DURATION_REGEX.test(form.duration);
-      const v3 = DESCRIPTION_REGEX.test(form.description);
-      const v4 = URL_REGEX.test(form.sourceCodeLink);
-      const v5 = URL_REGEX.test(form.liveLink);
-      const v6 = form.techStack.every((t) => TECH_STACK_ITEM_REGEX.test(t));
-
-      if (!v1 || !v2 || !v3 || !v4 || !v5 || !v6) {
-        showError("Invalid Entry");
-        return;
-      }
-
       try {
         const response = await axiosPrivate.post("/projects/create", form, {
           headers: {
@@ -210,7 +209,7 @@ function ProjectModal({ onClose, onSave, initialData }) {
             type="text"
             name="techStack"
             placeholder="Skills (e.g., React, Node)"
-            value={form.techStack.join(",")}
+            value={form.techStack.join(", ")}
             onChange={handleChange}
             className="input input-bordered w-full bg-base-100 text-base-content"
           />

--- a/client/src/assets/components/profile/ProjectsSec/ProjectModal.jsx
+++ b/client/src/assets/components/profile/ProjectsSec/ProjectModal.jsx
@@ -1,10 +1,23 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { axiosPrivate } from "../../../../api/axios";
 import useAuth from "../../../../auth/useAuth";
+import { FaTimesCircle,FaCheckCircle } from "react-icons/fa";
+
+// Toast imports
+import ErrorToast from "../../toast/ErrorToast";
+import { useErrorToast } from "../../toast/useErrorToast";
+import SuccessToast from "../../toast/SuccessToast";
+import { useSuccessToast } from "../../toast/useSuccessToast";
 
 function ProjectModal({ onClose, onSave, initialData }) {
   const { auth, setAuth } = useAuth();
   const [type, setType] = useState(initialData ? "update" : "Add");
+  const projectNameRef = useRef(null);
+  const errRef = useRef();
+
+  const [errMsg, setErrMsg] = useState("");
+  const [success, setSuccess] = useState(false);
+
   const [form, setForm] = useState({
     id: initialData?._id || "",
     title: initialData?.title || "",
@@ -16,28 +29,104 @@ function ProjectModal({ onClose, onSave, initialData }) {
     techStack: initialData?.techStack || [],
   });
 
-  console.log("initial data", initialData);
+  const {
+    message: errorMessage,
+    show: showErrorToast,
+    showError,
+  } = useErrorToast();
+
+  const {
+    message: successMessage,
+    show: showSuccessToast,
+    showSuccess,
+  } = useSuccessToast();
+
+  const [validTitle, setValidTitle] = useState(false);
+  const [validDuration, setValidDuration] = useState(false);
+  const [validDescription, setValidDescription] = useState(false);
+  const [validSource, setValidSource] = useState(false);
+  const [validLive, setValidLive] = useState(false);
+  const [validTechStack, setValidTechStack] = useState(false);
+
+  const TITLE_REGEX = /^[\w\s\-]{3,100}$/;
+  const DURATION_REGEX = /^[a-zA-Z]+-\d{4}-[a-zA-Z]+-\d{4}$/;
+  const DESCRIPTION_REGEX = /^.{10,}$/;
+  const URL_REGEX =
+    /^(https?:\/\/)?([\w-]+\.)+[\w-]+(\/[\w\-._~:/?#[\]@!$&'()*+,;=]*)?$/;
+  const TECH_STACK_ITEM_REGEX = /^[a-zA-Z0-9.+#-]{2,20}$/;
+
+  useEffect(() => {
+    projectNameRef.current.focus();
+  }, []);
+
+  useEffect(() => {
+    setValidTitle(TITLE_REGEX.test(form.title));
+    setValidDuration(DURATION_REGEX.test(form.duration));
+    setValidDescription(DESCRIPTION_REGEX.test(form.description));
+    setValidSource(URL_REGEX.test(form.sourceCodeLink));
+    setValidLive(URL_REGEX.test(form.liveLink));
+    setValidTechStack(
+      form.techStack.every((t) => TECH_STACK_ITEM_REGEX.test(t))
+    );
+  }, [form]);
+
   const handleChange = (e) => {
-    setForm({ ...form, [e.target.name]: e.target.value });
+    const { name, value } = e.target;
+    if (name === "techStack") {
+      setForm({
+        ...form,
+        techStack: value
+          .split(",")
+          
+      });
+    } else {
+      setForm({ ...form, [name]: value });
+    }
   };
+
+  useEffect(() => {
+    setErrMsg("");
+  }, [
+    form.id,
+    form.title,
+    form.duration,
+    form.description,
+    form.media,
+    form.sourceCodeLink,
+    form.liveLink,
+    form.techStack,
+  ]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     if (type === "Add") {
-      console.log(form);
+      const v1 = TITLE_REGEX.test(form.title);
+      const v2 = DURATION_REGEX.test(form.duration);
+      const v3 = DESCRIPTION_REGEX.test(form.description);
+      const v4 = URL_REGEX.test(form.sourceCodeLink);
+      const v5 = URL_REGEX.test(form.liveLink);
+      const v6 = form.techStack.every((t) => TECH_STACK_ITEM_REGEX.test(t));
+
+      if (!v1 || !v2 || !v3 || !v4 || !v5 || !v6) {
+        showError("Invalid Entry");
+        return;
+      }
+
       try {
         const response = await axiosPrivate.post("/projects/create", form, {
           headers: {
             Authorization: `Bearer ${auth?.accessToken}`,
           },
         });
+        showSuccess("Project added Successfully!");
+        setSuccess(true);
       } catch (err) {
-        console.log(err);
+        showError(`${JSON.stringify(err.response.data.message).slice(1, -1)}`);
+
+        errRef.current.focus();
       }
       onSave(form);
-   
     } else if (type === "update") {
-   
       const updatedForm = { _id: form.id };
 
       for (const key in form) {
@@ -60,10 +149,12 @@ function ProjectModal({ onClose, onSave, initialData }) {
             },
           }
         );
-        onClose(false)
-        onSave(response.data)
+        onClose(false);
+        onSave(response.data);
+        showSuccess("Project updated Successfully!");
+        setSuccess(true);
       } catch (err) {
-        console.log(err);
+        showError(`${JSON.stringify(err.response.data.message).slice(1, -1)}`);
       }
     }
   };
@@ -93,6 +184,7 @@ function ProjectModal({ onClose, onSave, initialData }) {
             placeholder="Project Title"
             value={form.title}
             onChange={handleChange}
+            ref={projectNameRef}
             className="input input-bordered w-full bg-base-100 text-base-content"
           />
 
@@ -118,7 +210,7 @@ function ProjectModal({ onClose, onSave, initialData }) {
             type="text"
             name="techStack"
             placeholder="Skills (e.g., React, Node)"
-            value={form.techStack}
+            value={form.techStack.join(",")}
             onChange={handleChange}
             className="input input-bordered w-full bg-base-100 text-base-content"
           />
@@ -164,6 +256,21 @@ function ProjectModal({ onClose, onSave, initialData }) {
           </div>
         </form>
       </div>
+
+      <SuccessToast
+        message={successMessage}
+        show={showSuccessToast}
+        status="success"
+        icon={<FaCheckCircle className="text-green-600 text-4xl" />}
+        iconBgColor="bg-green-700"
+      />
+      <ErrorToast
+        message={errorMessage}
+        show={showErrorToast}
+        status="error"
+        icon={<FaTimesCircle className="text-red-600 text-4xl" />}
+        iconBgColor="bg-red-700"
+      />
     </div>
   );
 }

--- a/client/src/assets/components/profile/ProjectsSec/ProjectModal.jsx
+++ b/client/src/assets/components/profile/ProjectsSec/ProjectModal.jsx
@@ -1,30 +1,92 @@
 import { useState } from "react";
+import { axiosPrivate } from "../../../../api/axios";
+import useAuth from "../../../../auth/useAuth";
 
 function ProjectModal({ onClose, onSave, initialData }) {
+  const { auth, setAuth } = useAuth();
+  const [type, setType] = useState(initialData ? "update" : "Add");
   const [form, setForm] = useState({
+    id: initialData?._id || "",
     title: initialData?.title || "",
     duration: initialData?.duration || "",
     description: initialData?.description || "",
-    skills: initialData?.skills || "",
-    image: initialData?.image || "",
+    media: initialData?.media || { images: [], videos: [] },
+    sourceCodeLink: initialData?.sourceCodeLink || "",
+    liveLink: initialData?.livelink || "",
+    techStack: initialData?.techStack || [],
   });
 
+  console.log("initial data", initialData);
   const handleChange = (e) => {
     setForm({ ...form, [e.target.name]: e.target.value });
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    onSave(form);
+    if (type === "Add") {
+      console.log(form);
+      try {
+        const response = await axiosPrivate.post("/project/create", form, {
+          headers: {
+            Authorization: `Bearer ${auth?.accessToken}`,
+          },
+        });
+        console.log(response.data);
+      } catch (err) {
+        console.log(err);
+      }
+      onSave(form);
+   
+    } else if (type === "update") {
+   
+      const updatedForm = { _id: form.id };
+
+      for (const key in form) {
+        const currentVal = form[key];
+        const initialVal = initialData?.[key];
+
+        if (JSON.stringify(currentVal) !== JSON.stringify(initialVal)) {
+          updatedForm[key] = currentVal;
+        }
+      }
+
+      try {
+        const response = await axiosPrivate.patch(
+          "/project/update",
+          updatedForm,
+
+          {
+            headers: {
+              Authorization: `Bearer ${auth?.accessToken}`,
+            },
+          }
+        );
+        onClose(false)
+        console.log("updated project",response.data)
+        onSave(response.data)
+      } catch (err) {
+        console.log(err);
+      }
+    }
+  };
+
+  const handleImageChange = (e) => {
+    const url = e.target.value.trim();
+    setForm((prev) => ({
+      ...prev,
+      media: {
+        ...prev.media,
+        images: url ? [url] : [],
+      },
+    }));
   };
 
   return (
-<div className="fixed inset-0 bg-black bg-opacity-40 flex justify-center items-center z-50">
-  <div className="bg-base-200 p-4 sm:p-8 rounded-xl shadow-xl w-[95%] max-w-2xl">
-    <h2 className="text-2xl font-semibold text-base-content mb-4">
-      {initialData ? "Edit Project" : "Add Project"}
-    </h2>
-
+    <div className="fixed inset-0 bg-black bg-opacity-40 flex justify-center items-center z-50">
+      <div className="bg-base-200 p-4 sm:p-8 rounded-xl shadow-xl w-[95%] max-w-2xl">
+        <h2 className="text-2xl font-semibold text-base-content mb-4">
+          {initialData ? "Edit Project" : "Add Project"}
+        </h2>
 
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           <input
@@ -56,18 +118,36 @@ function ProjectModal({ onClose, onSave, initialData }) {
 
           <input
             type="text"
-            name="skills"
+            name="techStack"
             placeholder="Skills (e.g., React, Node)"
-            value={form.skills}
+            value={form.techStack}
             onChange={handleChange}
             className="input input-bordered w-full bg-base-100 text-base-content"
           />
 
           <input
             type="text"
-            name="image"
+            name="images"
             placeholder="Image URL"
-            value={form.image}
+            value={form.media.images[0] || ""}
+            onChange={handleImageChange}
+            className="input input-bordered w-full bg-base-100 text-base-content"
+          />
+
+          <input
+            type="text"
+            name="sourceCodeLink"
+            placeholder="Github URL"
+            value={form.sourceCodeLink}
+            onChange={handleChange}
+            className="input input-bordered w-full bg-base-100 text-base-content"
+          />
+
+          <input
+            type="text"
+            name="liveLink"
+            placeholder="Live Preview URL"
+            value={form.liveLink}
             onChange={handleChange}
             className="input input-bordered w-full bg-base-100 text-base-content"
           />
@@ -81,7 +161,7 @@ function ProjectModal({ onClose, onSave, initialData }) {
               Cancel
             </button>
             <button type="submit" className="btn btn-primary">
-              {initialData ? "Update" : "Add"}
+              {type}
             </button>
           </div>
         </form>

--- a/server/controllers/projectController.js
+++ b/server/controllers/projectController.js
@@ -1,0 +1,148 @@
+const Project = require("../models/Project");
+const User = require("../models/User");
+
+const createProject = async (req, res) => {
+  const userId = req.user.id;
+
+  if (!req.user || !req.user.id) {
+    return res.status(401).json({ messaeg: "unauthorized user" });
+  }
+
+  if (!req.body || !req.body.title || !req.body.description) {
+    return res
+      .status(400)
+      .json({ message: "Title and description are required" });
+  }
+
+  JSON.stringify(req.body.media);
+  try {
+    const {
+      title,
+      description,
+      media,
+      tags,
+      userTags,
+      techStack,
+      liveLink,
+      sourceCodeLink,
+      duration,
+    } = req.body;
+
+    const slug = title
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+
+    const newProject = await Project.create({
+      title,
+      description,
+      media,
+      tags,
+      userTags,
+      techStack,
+      liveLink,
+      sourceCodeLink,
+      duration,
+      slug,
+      owner: userId,
+    });
+
+    const user = await User.findByIdAndUpdate(userId, {
+      $push: { projects: newProject._id },
+    });
+
+    res.status(201).send({
+      message: "Project created successfully",
+      result: newProject,
+    });
+  } catch (err) {
+    res.status(500).json({ message: "Error creating project." });
+  }
+};
+
+const deleteProject = async (req, res) => {
+  if (!req.params || !req.params.id) {
+    return res.status(400).json({ message: "Project Id is required" });
+  }
+
+  if (!req.user || !req.user.id) {
+    return res.status(401).json({ message: "Unauthorized user" });
+  }
+  try {
+
+    const { id } = req.params;
+    const project = await Project.findOneAndDelete({
+      _id: id,
+      owner: req.user.id,
+    });
+
+    if (!project) {
+      return res.status(404).json({ message: "Project not found" });
+    }
+
+    await User.findByIdAndUpdate(req.user.id, {
+      $pull: { projects: project._id },
+    });
+
+    return res.status(200).json({
+      message: "Project deleted successfully",
+      reult: project,
+    });
+  } catch (err) {
+    return res.status(500).json({ message: "Error deleting project" });
+  }
+};
+
+const updateProject = async (req, res) => {
+  const { _id, owner, ...updates } = req.body; 
+
+   if(!req.user || !req.user.id){
+    return res.status(401).json({message:"unauthorized user"})
+   }
+
+   if(!updates || Object.keys(updates).length===0){
+     return res.status(400).json({message:"No updates provided"})
+   }
+
+  try {
+    const project = await Project.findOneAndUpdate(
+       {_id},
+       { $set: updates },
+       { new: true, runValidators: true }
+    );
+   
+    if (!project) {
+      return res.status(404).json({ message: "Project not found" });
+    }
+
+    return res.status(200).json({
+      message: "Project updated successfully",
+      result: project,
+    });
+
+  } catch (err) {  
+    return res.status(500).json({ message: "Error updating project" });
+  }
+};
+
+const getAllProjects = async (req, res) => {
+  if (!req.user || !req.user.id) {
+    return res.status(401).json({ message: "unauthorized user" });
+  }
+
+  try {
+
+    const projects = await Project.find({ owner: req.user.id });
+    
+    if(!projects || projects.length ===0){
+      return res.status(404).json({message:"No project found"})
+    }
+ 
+    return res.status(200).json(projects);
+  } catch (err) {
+    return res.status(500).json({ message: "Error fetching projects" });
+  }
+};
+
+module.exports = { createProject, deleteProject, getAllProjects ,updateProject};

--- a/server/controllers/projectController.js
+++ b/server/controllers/projectController.js
@@ -5,7 +5,7 @@ const createProject = async (req, res) => {
   const userId = req.user.id;
 
   if (!req.user || !req.user.id) {
-    return res.status(401).json({ messaeg: "unauthorized user" });
+    return res.status(401).json({ messaeg: "Unauthorized user" });
   }
 
   if (!req.body || !req.body.title || !req.body.description) {
@@ -98,7 +98,7 @@ const updateProject = async (req, res) => {
   const { _id, owner, ...updates } = req.body; 
 
    if(!req.user || !req.user.id){
-    return res.status(401).json({message:"unauthorized user"})
+    return res.status(401).json({message:"Unauthorized user"})
    }
 
    if(!updates || Object.keys(updates).length===0){
@@ -128,7 +128,7 @@ const updateProject = async (req, res) => {
 
 const getAllProjects = async (req, res) => {
   if (!req.user || !req.user.id) {
-    return res.status(401).json({ message: "unauthorized user" });
+    return res.status(401).json({ message: "Unauthorized user" });
   }
 
   try {
@@ -136,7 +136,7 @@ const getAllProjects = async (req, res) => {
     const projects = await Project.find({ owner: req.user.id });
     
     if(!projects || projects.length ===0){
-      return res.status(404).json({message:"No project found"})
+      return res.status(200).json({message:"No project found",projects:[]})
     }
  
     return res.status(200).json(projects);

--- a/server/models/Project.js
+++ b/server/models/Project.js
@@ -4,10 +4,10 @@ const mongoose = require('mongoose');
 const projectSchema = new mongoose.Schema({
     title: { type: String, required: true },
     description: { type: String, required: true },
-    media: {
-        images: [String],
-        videos: [String]
-    },
+    media: { 
+        images:{type: [String], default: []},
+        videos:{type: [String], default: []}
+     },
 
     tags: { type: [String], default: [] },
     userTags: { type: [String], default: [] },
@@ -16,8 +16,8 @@ const projectSchema = new mongoose.Schema({
     liveLink: { type: String, default: '' },
     sourceCodeLink: { type: String, default: '' },
 
-    startDate: { type: Date },
-    endDate: { type: Date },
+    
+    duration:{type:String,default:Date.now()},
 
     // For Project URL
     slug: { type: String, unique: true },

--- a/server/routes/projectRoutes.js
+++ b/server/routes/projectRoutes.js
@@ -1,24 +1,28 @@
-const express = require('express');
+const express = require("express");
 const router = express.Router();
-const { verifyJWT } = require('../middleware/verifyJWT');
-const { verifyRoles } = require('../middleware/verifyRoles');
-const {createProject}=require('../controllers/projectController.js')
-const {deleteProject}=require('../controllers/projectController.js')
-const {getAllProjects}=require('../controllers/projectController.js')
-const {updateProject}=require('../controllers/projectController.js')
+const { verifyJWT } = require("../middleware/verifyJWT");
+const { verifyRoles } = require("../middleware/verifyRoles");
+const {
+  createProject,
+  deleteProject,
+  getAllProjects,
+  updateProject,
+} = require("../controllers/projectController.js");
 
+router
+  .route("/create")
+  .post(verifyJWT, verifyRoles("user", "admin", "owner"), createProject);
 
-router.route('/create')
-    .post(verifyJWT, verifyRoles('user', 'admin', 'owner'), createProject)
+router
+  .route("/:id")
+  .delete(verifyJWT, verifyRoles("user", "admin", "owner"), deleteProject);
 
-router.route('/:id')  
-    .delete(verifyJWT,verifyRoles('user','admin','owner'),deleteProject)
+router
+  .route("/allProjects")
+  .get(verifyJWT, verifyRoles("user", "admin", "owner"), getAllProjects);
 
-router.route('/allProjects')  
-    .get(verifyJWT,verifyRoles('user','admin','owner'),getAllProjects)
-
-router.route('/update')  
-    .patch(verifyJWT,verifyRoles('user','admin','owner'),updateProject)
-
+router
+  .route("/update")
+  .patch(verifyJWT, verifyRoles("user", "admin", "owner"), updateProject);
 
 module.exports = router;

--- a/server/routes/projectRoutes.js
+++ b/server/routes/projectRoutes.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const router = express.Router();
+const { verifyJWT } = require('../middleware/verifyJWT');
+const { verifyRoles } = require('../middleware/verifyRoles');
+const {createProject}=require('../controllers/projectController.js')
+const {deleteProject}=require('../controllers/projectController.js')
+const {getAllProjects}=require('../controllers/projectController.js')
+const {updateProject}=require('../controllers/projectController.js')
+
+
+router.route('/create')
+    .post(verifyJWT, verifyRoles('user', 'admin', 'owner'), createProject)
+
+router.route('/:id')  
+    .delete(verifyJWT,verifyRoles('user','admin','owner'),deleteProject)
+
+router.route('/allProjects')  
+    .get(verifyJWT,verifyRoles('user','admin','owner'),getAllProjects)
+
+router.route('/update')  
+    .patch(verifyJWT,verifyRoles('user','admin','owner'),updateProject)
+
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -22,6 +22,7 @@ const refreshRoutes = require('./routes/refreshRoutes');
 const logoutRoutes = require('./routes/logoutRoutes');
 const profileRoutes = require('./routes/profileRoutes');
 const blogPostRoutes = require('./routes/blogPostRoutes');
+const projectRoutes=require('./routes/projectRoutes')
 
 // Middleware
 app.use(express.json());
@@ -48,6 +49,8 @@ app.use('/profile', profileRoutes);
 
 // Blog Post Routes
 app.use('/api/posts', blogPostRoutes)
+
+app.use('/project',projectRoutes)
 
 app.listen(port, () => {
     console.log(`Server running on port: ${port}`);

--- a/server/server.js
+++ b/server/server.js
@@ -50,7 +50,7 @@ app.use('/profile', profileRoutes);
 // Blog Post Routes
 app.use('/api/posts', blogPostRoutes)
 
-app.use('/project',projectRoutes)
+app.use('/projects',projectRoutes)
 
 app.listen(port, () => {
     console.log(`Server running on port: ${port}`);


### PR DESCRIPTION
This PR implements the complete Create, Read, Update, and Delete (CRUD) functionality for user projects, both on the backend (following MVC architecture) and frontend.

🚀 Backend Changes:
 User can create and save a project linked to their profile (POST /project)
 User can edit their own projects (PATCH /project)
 User can delete their own projects (DELETE /project/:id)
 Anyone can view public projects of a user (GET /project/allProjects)

Access control is enforced using req.user.id to ensure only the owner can modify or delete their projects.

💻 Frontend Changes:
 Added project creation modal with fields: title, duration, description, skills, image/video URLs, live link, and source code link
 Displayed project cards under the Projects section of the user's profile
 Enabled editing a project via the card's edit button
 Enabled deleting a project via the card's delete button
 Public viewing of another user's project list is supported

📦 Extras:
Toast notifications for success/failure on create, edit, delete
Refactored ProjectModal, ProjectCopo, and Project components for clean logic separation
API integration uses axiosPrivate with auth headers
